### PR TITLE
New slash command: /github_repo added

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,21 +9,14 @@ A Discord bot that integrates with GitHub to provide user profile information an
 - 🚀 **Render Optimized**: Specifically configured for reliable Render.com deployment
 - ⚡ **Slash Commands**: Modern Discord slash command interface
 - 🛡️ **Rate Limit Handling**: Smart GitHub API rate limit management
-- 📊 **Connection Monitoring**: Automatic reconnection and error recovery
-
 ## 🤖 Available Commands
 
 | Command | Description | Usage |
 |---------|-------------|-------|
 | `/ping` | Test bot connectivity and check latency | `/ping` |
 | `/github_user` | Get detailed GitHub user profile | `/github_user username:octocat` |
+| `/github_repo` | Get GitHub repository details (stars, forks, issues, license, topics) | `/github_repo repo:octocat/Hello-World` |
 | `/sync_commands` | Manually sync commands (Admin only) | `/sync_commands` |
-
-## 🚀 Quick Start
-
-### Prerequisites
-
-- Python 3.10 or higher
 - Discord Bot Token
 - GitHub Personal Access Token (optional, but recommended for higher rate limits)
 - Discord Server (Guild) ID


### PR DESCRIPTION
We’ve added a new command to the bot: /github_repo, now live in bot.py as github_repo().

What it does:

Accepts either owner/repo format or a full GitHub URL (e.g., octocat/Hello-World)

Pulls repository data via the GitHub API

Displays key info:

⭐ Stars, 🍴 Forks, 🐛 Open Issues

🗣️ Primary Language, 📄 License

🕒 Last Updated

🏷️ Topics (if available)

🔗 Quick links to homepage and repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added /github_repo slash command to fetch and display GitHub repository details (description, stars, forks, issues, language, license, last updated, topics, links) with clear handling of invalid repos, rate limits, and failures.

* **Documentation**
  * Updated Available Commands to include /github_repo.
  * Removed Connection Monitoring bullet.
  * Removed Quick Start and prerequisites (including Python version), streamlining the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->